### PR TITLE
Fix issue with getAccessPage() not working properly for Repeaters

### DIFF
--- a/UserGroupsHooks.module
+++ b/UserGroupsHooks.module
@@ -25,7 +25,7 @@ class UserGroupsHooks extends WireData implements Module {
 
 		return array(
 			'title' => 'User Groups Hooks',
-			'version' => 14,
+			'version' => 15,
 			'summary' => 'Autoload module that attachs all the hooks required by User Groups.',
 			'singular' => true,
 			'autoload' => true,
@@ -584,6 +584,14 @@ class UserGroupsHooks extends WireData implements Module {
 	public function getAccessPage($page) {
 		if ( ! isset($page) ) return false;
 		if ( ! $page->id ) return false;
+
+		// If this is a Repeater Page, access is managed elsewhere
+		if (substr($page->template, 0, 9) == "repeater_") {
+			if (preg_match("/\/for-page-([0-9]+)\//", $page->url, $matches)) {
+				$page = $this->pages->get($matches[1]);
+				if (!$page->id) return false;
+			}
+		}
 
 		// If page doesn't have manage_access field at all, no need to continue
 		if ( ! $page->template->hasField($this->fieldManageAccess)) return false;


### PR DESCRIPTION
This PR adds Repeater support to getAccessPage() and fixes an issue where secure files weren't viewable at all for some users.

I'm not merging this to master yet, as I'd like to get a second opinion on this first. I'm not really familiar with UserGroupsHooks and it's features, so it's possible that I'm missing something obvious here, or perhaps there's a cleaner way to do the same thing?

/cc @apeisa @niklaka 

PS. While pushing this branch to GitHub, I managed to bring in couple of local commits that were never intended here. Minor stuff, file permissions and such. I've already reverted the changes, sorry for making unnecessary mess in the commit history :)