### PR TITLE
Switch bootstrap method from ng-app to angular.bootstrap()

### DIFF
--- a/UserGroupsHooks.module
+++ b/UserGroupsHooks.module
@@ -25,7 +25,7 @@ class UserGroupsHooks extends WireData implements Module {
 
 		return array(
 			'title' => 'User Groups Hooks',
-			'version' => 14,
+			'version' => 15,
 			'summary' => 'Autoload module that attachs all the hooks required by User Groups.',
 			'singular' => true,
 			'autoload' => true,

--- a/ng-access.php
+++ b/ng-access.php
@@ -1,5 +1,5 @@
 <!-- all the Angular related markup goes inside this extra wrapper for it to be accessible by AccessApp/AccessCtrl -->
-<div xmlns:ng="http://angularjs.org" id="ng-app" ng-app="AccessApp" ng-controller="AccessCtrl">
+<div xmlns:ng="http://angularjs.org" id="ng-access-app" ng-controller="AccessCtrl">
 	<label>
 		<input type="radio" name="manage_access" value="1" ng-model="manageAccess" ng-change="init()" />
 		{{ i18n.labelManageHere }}
@@ -54,3 +54,5 @@
 		class="ng-hide">
 	</select>
 </div>
+
+<script>angular.bootstrap(document.getElementById('ng-access-app'), ['AccessApp']);</script>


### PR DESCRIPTION
Switching to angular.bootstrap() enables multiple AngularJS apps to live on single HTML document. Previously used ng-app directive only works for single app.

This isn't as clean as the ng-app bootstrap method, but considering that other admin tools might also use AngularJS, this is definitely the preferred solution. This came up while trying to implement UserGroups and FieldtypePoll on same site. Based on some Googling, manually calling angular.bootstrap() for each app seems to be the only way to make this work.

@apeisa @niklaka Unless you see any potential issues with this, I'm going to merge this into master soon. This is working fine for me on one test site, but that's the extent of testing I've done so far.

Note to @apeisa: FieldtypePoll required a similar change. I might send a pull request for that later :)